### PR TITLE
Add logging mechanism + code style fixes

### DIFF
--- a/autoeis/__init__.py
+++ b/autoeis/__init__.py
@@ -1,7 +1,16 @@
 from ._funcs import *
 
-
 __version__ = "0.0.15"
 __description__ = "A demo package to assist EIS analysis by automatically proposing statistically plausible ECM "
 __author__ = "Runze Zhang, Robert Black, Jason Hattrick-Simpers"
 __contact_information = "runzee.zhang@mail.utoronto.ca"
+
+
+import logging
+
+from rich.logging import RichHandler
+
+FORMAT = "%(message)s"
+logging.basicConfig(
+    level="WARNING", format=FORMAT, datefmt="[%X]", handlers=[RichHandler()]
+)

--- a/autoeis/_funcs.py
+++ b/autoeis/_funcs.py
@@ -2278,7 +2278,6 @@ def EIS_auto(
     # Preprocessing + store preprocessed data
     print("> Data processing...")
     data_processed, ohmic_resistance, RMSE = pre_processing(impedance, freq, 0.05, fname)
-    data_processed, ohmic_resistance, RMSE = pre_processing(impedance, freq, 0.05, fname)    
     path_data_preprocessed = save_processed_data(input_name=fname, data=data_processed)
 
     # Call EquivalentCircuits.jl

--- a/autoeis/_funcs.py
+++ b/autoeis/_funcs.py
@@ -2301,99 +2301,28 @@ def EIS_auto(
     new_df = combine_expression(df_circuits)
     new_df = calculate_length(new_df)
     new_df = split_variables(new_df)
-    results = Bayesian_inference(
-        data=data_processed, data_path=fname, df=new_df, ECM_figure=plot_ECM
-    )
+    results = Bayesian_inference(data=data_processed, data_path=fname, df=new_df, ECM_figure=plot_ECM)
 
-    return results
-
-
-def EIS_auto_script(
-    impedance: "np.ndarray",
-    freq: "np.ndarray",
-    data_path: str,
-    iter_number: int = 100,
-    plot_ECM: bool = False,
-) -> "pd.DataFrame":
-    """
-    The main function to automate the whole EIS analysis by ECMs + BI.
-
-    Parameters
-    ----------
-    impedance: np.ndarray
-        The impedance data
-    freq: np.ndarray
-        The frequencies of the impedance data
-    data_path: str
-        The data path of the impedance data
-    iter_number: int
-        The number of times the ECM generation is performed
-    plot_ECM: bool
-        Determine whether to plot ECM or not
-
-    Returns
-    -------
-    results: pd.DataFrame
-        Dataframe containing effective ECMs after filtering + BI results (12 columns)
-
-    """
-    # Set the plotting style
-    set_parameter()
-    ec, jl_df, jl_pd, jl_Base = import_julia()
-
-    # Preprocessing + store preprocessed data
-    print("---------------Data_preprocessing---------------")
-    data_processed, ohmic_resistance, RMSE = pre_processing(impedance, freq, 0.05, data_path)
-    path_data_preprocessed = save_processed_data(
-        input_name=data_path, data=data_processed
-    )
-
-    # ECM generation
-    print("---------------ECM generation in process---------------")
-    # Alternative method: direcly call julia script - this might be faster
-    run_julia = j.include("test_julia.jl")
-
-    # Load the results - 1.from the results file
-    path_results = "df_results.csv"
-    df_circuits = load_results(fname=path_results)
-
-    # Load the results
-    df_circuits = split_components(df_results)
-    df_circuits = capacitance_filter(df_circuits)
-    df_circuits = series_filter(df_circuits)
-    df_circuits = ohmic_resistance_filter(df_circuits, ohmic_resistance)
-    df_circuits = generate_mathematical_expression(df_circuits)
-    new_df = combine_expression(df_circuits)
-    new_df = calculate_length(new_df)
-    new_df = split_variables(new_df)
-    results = Bayesian_inference(
-        data=data_processed, data_path=data_path, df=new_df, ECM_figure=plot_ECM
-    )
     return results
 
 
 if __name__ == "__main__":
-    # Define the path of julia program
-    j = set_julia(r"D:\Julia-1.7.2\bin\julia.exe")
+    import autoeis as ae
 
-    # Initialize the julia environment
-    # Initialize_julia()
+    # Initialize Julia
+    jl = ae.set_julia("/home/amin/.juliaup/bin/julia")
+    ae.initialize_julia()
+    ae.set_parameter()
 
-    # Set the parameter of plots
-    set_parameter()
-
-    # Load the EIS data and get access to the impedance and frequencies
-    fname = "Test_data.txt"
+    # Load the EIS data
+    fname = "testdata.txt"
     df = load_data(fname)
-
+    # Fetch frequency and impedance data
     frequencies = np.array(df["freq/Hz"]).astype(float)
     reals = np.array(df["Re(Z)/Ohm"]).astype(float)
     imags = -np.array(df["-Im(Z)/Ohm"]).astype(float)
 
+    # Perform EIS analysis
     measurements = reals + imags * 1j
-
-    # Analysis board
-    results = EIS_auto(
-        impedance=measurements, freq=frequencies, fname=fname, iter_number=100
-    )
+    results = EIS_auto(impedance=measurements, freq=frequencies, fname=fname, iter_number=100)
     print(results)

--- a/autoeis/_funcs.py
+++ b/autoeis/_funcs.py
@@ -2276,16 +2276,16 @@ def EIS_auto(
     ec, jl_df, jl_pd, jl_Base = import_julia()
 
     # Preprocessing + store preprocessed data
-    print("---------------Data_processing---------------")
+    print("> Data processing...")
     data_processed, ohmic_resistance, RMSE = pre_processing(impedance, freq, 0.05, fname)
-    path_data_preprocessed = save_processed_data(
-        input_name=fname, data=data_processed
-    )
+    data_processed, ohmic_resistance, RMSE = pre_processing(impedance, freq, 0.05, fname)    
+    path_data_preprocessed = save_processed_data(input_name=fname, data=data_processed)
 
-    # Call julia program
-    print("---------------ECM generation in process---------------")
+    # Call EquivalentCircuits.jl
+    print("> ECM generation in progress...")
     df_results = ECM_generation(data=data_processed, times=iter_number)
-    # an alternative method: direcly call julia script - this might be faster
+    if df_results is None: return
+    # Alternative: Direcly call Julia script (might be faster)
     # run_julia = j.include('test_julia.jl')
 
     # Load the results - 1.from the results file

--- a/autoeis/_funcs.py
+++ b/autoeis/_funcs.py
@@ -210,9 +210,9 @@ def plot_EIS(
         fig, ax = plt.subplots(figsize=(5, 3.5), dpi=300)
 
         # Magnitude plot
-        ax.scatter(np.log10(frequencies), magnitude, c="b", label="Magnitude")
+        ax.scatter(np.log10(frequencies), magnitude, c="b", label="magnitude")
         ax.set_xlabel("log(freq)")
-        ax.set_ylabel("Magnitude")
+        ax.set_ylabel("magnitude")
         ax.set_title("Bode plot")
         # Phase plot
         ax2 = ax.twinx()
@@ -259,9 +259,8 @@ def find_ohmic_resistance(
         dirStr, ext = os.path.splitext(fname)
         folder_name = dirStr.split("\\")[-1]
         mkdir(folder_name)
-        with open(
-            f"{folder_name}\\ohmic_resistance = {round(ohmic_resistance, 4)}.txt", "w"
-        ) as f:
+        saveto = os.path.join(folder_name, "ohmic_resistance.txt")
+        with open(saveto, "w") as f:
             f.write(f"ohmic resistance = {ohmic_resistance}")
 
     return ohmic_resistance
@@ -374,11 +373,12 @@ def pre_processing(
     plt.plot(freq, res_imag, label="delta Im")
     plt.plot(freq, res_real, label="delta Re")
     plt.xlabel("freq (Hz)")
-    plt.ylabel("Delta %")
+    plt.ylabel("delta %")
     plt.xscale("log")
-    plt.title("Lin-KK Validation")
+    plt.title("Lin-KK validation")
     plt.legend()
-    plt.savefig(f"{folder_name}\\Lin-KK Validation.png", dpi=300)
+    saveto = os.path.join(folder_name, "Lin-KK validation.png")
+    fig.savefig(saveto, dpi=300)
 
     # Need to set a threshold limit for when to filter out the noisy data
     # of the residuals threshold = 0.05 # USER DEFINE!!!
@@ -425,7 +425,7 @@ def pre_processing(
         Zdf_mask = pd.DataFrame(values_mask.transpose(), columns=labels)
         threshold += 0.01
 
-    print(f"ohmic_resistance = {ohmic_resistance}")
+    print(f"ohmic resistance = {ohmic_resistance}")
 
     # Plot the data to see how the filter performed
     fig, axes = plt.subplots(1, 3, figsize=(15, 3.5), dpi=300)
@@ -1871,8 +1871,8 @@ def Bayesian_inference(
         mkdir(folder_name + f"\\{circuit_name_i}")
         os.chdir(folder_name + f"\\{circuit_name_i}")
 
-        print(f"----------Circuit {i}:{circuit_name_i}--------------")
-        print(f"Circuit elements: {name_i})  \nValues: ({value_i})")
+        print(f"> Circuit {i}: {circuit_name_i}")
+        print(f"Elements: ({name_i})\nValues: ({value_i})")
 
         if plot:
             if ECM_figure:
@@ -1881,40 +1881,40 @@ def Bayesian_inference(
         ECM_data = function_i(value_i, freq)
         ECMs_data.append(ECM_data)
 
-        print("Julia circuit's fitting")
+        print("> Julia circuit's fitting")
 
         r2_value = float(r2_calculator(Zreal + 1j * Zimag, ECM_data))
-        print(f"r2_value:{r2_value}")
+        print(f"  r2_value:{r2_value}")
         R2_list.append(r2_value)
 
         r2_real = r2_calculator(Zreal, ECM_data.real)
-        print(f"r2_real_part:{r2_real}")
+        print(f"  r2_real_part:{r2_real}")
         R2_real_list.append(r2_real)
         r2_imag = r2_calculator(Zimag, ECM_data.imag)
-        print(f"r2_imag_part:{r2_imag}")
+        print(f"  r2_imag_part:{r2_imag}")
         R2_imag_list.append(r2_imag)
 
         MSE_value = float(MSE_calculator(Zreal + 1j * Zimag, ECM_data))
-        print(f"MSE_value:{MSE_value}")
+        print(f"  MSE_value:{MSE_value}")
         MSE_list.append(MSE_value)
 
         RMSE_value = float(MSE_calculator(Zreal + 1j * Zimag, ECM_data) ** (1 / 2))
-        print(f"RMSE_value:{RMSE_value}")
+        print(f"  RMSE_value:{RMSE_value}")
         RMSE_list.append(RMSE_value)
 
         MAPE_value = float(MAPE_calculator(Zreal + 1j * Zimag, ECM_data) ** (1 / 2))
-        print(f"MAPE_value:{MAPE_value}")
+        print(f"  MAPE_value:{MAPE_value}")
         MAPE_list.append(MAPE_value)
 
         if plot:
-            plt.scatter(ECM_data.real, -ECM_data.imag, c="r", s=12, label="Simulated data")
-            plt.scatter(Zreal, -Zimag, c="b", s=12, label="Original data")
-            plt.xlabel("Real impedance")
-            plt.ylabel("- Imag impedance")
-            plt.title("Nyquist plots of original data and simulated data")
+            plt.scatter(ECM_data.real, -ECM_data.imag, c="r", s=12, label="simulated")
+            plt.scatter(Zreal, -Zimag, c="b", s=12, label="original")
+            plt.xlabel("Real(impedance)")
+            plt.ylabel("-Im(impedance)")
+            plt.title("Nyquist plots of original and simulated data")
             plt.legend()
             if save:
-                plt.savefig(f"Nyquist_plots_of_simulated_data.png", dpi=300)
+                plt.savefig(f"Nyquist_simulated.png", dpi=300)
             plt.show()
 
         def model_i(
@@ -1976,7 +1976,7 @@ def Bayesian_inference(
 
         # Prior distributions
         if plot:
-            print(f"{circuit_name_i}:Prior distributions with trajectories")
+            print(f"{circuit_name_i}: Prior distributions with trajectories")
             az.plot_trace(prior_prediction, var_names=name_i)
             if save:
                 plt.savefig(f"Prior distributions.png", dpi=300)
@@ -1984,7 +1984,7 @@ def Bayesian_inference(
 
         # Prior predictions
         if plot:
-            print(f"{circuit_name_i}:Prior prediction")
+            print(f"{circuit_name_i}: Prior prediction")
             _, ax = plt.subplots()
 
         prior_R2_list = []
@@ -2002,16 +2002,16 @@ def Bayesian_inference(
                 ax.plot(y.real, -y.imag, color="k", alpha=0.4)
         if plot:
             ax.plot(Zreal, -Zimag, c="b", alpha=1)
-            ax.set_xlabel("real impedance ")
-            ax.set_ylabel("imag impedance")
+            ax.set_xlabel("Real(impedance)")
+            ax.set_ylabel("Im(impedance)")
             ax.set_title("Prior predictive checks")
             if save:
-                plt.savefig(f"Prior prediction.png", dpi=300)
+                plt.savefig(f"Prior predictions.png", dpi=300)
             plt.show()
 
         # Posterior distributions
         if plot:
-            print(f"{circuit_name_i}:Posterior distributions with HDI")
+            print(f"{circuit_name_i}: Posterior distributions with HDI")
             for i in range(len(name_i)):
                 name = name_i[i]
                 value = value_i[i]
@@ -2027,21 +2027,21 @@ def Bayesian_inference(
             # #                         new_lim = np.multiply(posterior_HDI[i][j].get_xlim(),value_i[rc_id])
             # #                         posterior_HDI[i][j].set_xlim(new_lim)
             if save:
-                plt.savefig(f"Posterior prediction_with HDI.png", dpi=300)
+                plt.savefig(f"Posterior predictions with HDI.png", dpi=300)
             plt.show()
 
         # Posterior trajectories
         posterior_dist = az.plot_trace(trace, var_names=name_i)
 
         if plot:
-            print(f"{circuit_name_i}:Posterior distributions with trajectories")
+            print(f"{circuit_name_i}: Posterior distributions with trajectories")
             if save:
                 plt.savefig(f"Posterior distributions.png", dpi=300)
             plt.show()
 
         # Posterior predictions -- real part
         if plot:
-            print(f"{circuit_name_i}:Posterior predictions - real part")
+            print(f"{circuit_name_i}: Posterior predictions - real part")
             _, ax = plt.subplots()
 
         samples = mcmc_i.get_samples()
@@ -2075,37 +2075,19 @@ def Bayesian_inference(
         Posterior_mape_real.append(avg_mape_real)
 
         if plot:
-            ax.plot(
-                np.log10(freq),
-                BI_data.real,
-                marker=".",
-                ms=15,
-                color="grey",
-                alpha=0.5,
-                label="Predictive EIS",
-            )
-            ax.plot(
-                np.log10(freq),
-                Zreal,
-                "--",
-                marker="o",
-                c="b",
-                alpha=0.9,
-                ms=8,
-                label="Ground Truth EIS",
-            )
-
+            ax.plot(np.log10(freq), BI_data.real, marker=".", ms=15, color="grey", alpha=0.5, label="predictive EIS")
+            ax.plot(np.log10(freq), Zreal, "--", marker="o", c="b", alpha=0.9, ms=8, label="ground truth EIS")
             ax.set_xlabel("log(freq)")
-            ax.set_ylabel("real impedance")
-            ax.set_title("Posterior predictive checks - Real parts")
+            ax.set_ylabel("Real(impedance)")
+            ax.set_title("Posterior predictive checks (Real)")
             if save:
-                plt.savefig(f"Posterior prediction_real parts.png", dpi=300)
+                plt.savefig(f"Posterior predictions (Real).png", dpi=300)
             plt.legend()
             plt.show()
 
         # Posterior predictions -- imag part
         if plot:
-            print(f"{circuit_name_i}:Posterior predictions imag")
+            print(f"{circuit_name_i}: Im(Posterior predictions)")
             _, ax = plt.subplots()
 
         sep_mape_imag_list = []
@@ -2135,37 +2117,19 @@ def Bayesian_inference(
         Posterior_r2_imag.append(avg_r2_imag)
         Posterior_mape_imag.append(avg_mape_imag)
         if plot:
-            ax.plot(
-                np.log10(freq),
-                -BI_data.imag,
-                marker=".",
-                ms=15,
-                color="grey",
-                alpha=0.5,
-                label="Predictive EIS",
-            )
-            ax.plot(
-                np.log10(freq),
-                -Zimag,
-                "--",
-                marker="o",
-                c="b",
-                alpha=0.9,
-                ms=8,
-                label="Ground Truth EIS",
-            )
-
+            ax.plot(np.log10(freq), -BI_data.imag, marker=".", ms=15, color="grey", alpha=0.5, label="predictive EIS")
+            ax.plot(np.log10(freq), -Zimag, "--", marker="o", c="b", alpha=0.9, ms=8, label="ground truth EIS")
             ax.set_xlabel("log(freq) ")
-            ax.set_ylabel("-imag impedance")
-            ax.set_title("Posterior predictive checks - Imag parts")
+            ax.set_ylabel("-Im(impedance)")
+            ax.set_title("Posterior predictive checks (Im)")
             if save:
-                plt.savefig(f"Posterior prediction_imag parts.png", dpi=300)
+                plt.savefig(f"Posterior predictions (Im).png", dpi=300)
             plt.legend()
             plt.show()
 
         # Posterior predictions
         if plot:
-            print(f"{circuit_name_i}:Posterior predictions")
+            print(f"{circuit_name_i}: Posterior predictions")
             _, ax = plt.subplots()
 
         sep_mape_list = []
@@ -2196,25 +2160,15 @@ def Bayesian_inference(
         Posterior_mape.append(avg_mape)
 
         if plot:
-            #             ax.plot(BI_data.real, -BI_data.imag ,marker='.',ms=15,color='grey', alpha=0.5,label='Predictive EIS')
-            #             ax.plot(Zreal,-Zimag,'--',marker='o',c='b',alpha=0.9,ms=8,label = 'Ground Truth EIS')
-            ax.plot(
-                BI_data.real,
-                -BI_data.imag,
-                marker=".",
-                ms=15,
-                color="grey",
-                alpha=0.5,
-                label="Predictions",
-            )
-            ax.plot(
-                Zreal, -Zimag, "--", marker="o", c="b", alpha=0.9, ms=8, label="Ground Truth"
-            )
-            ax.set_xlabel("real impedance ")
-            ax.set_ylabel("imag impedance")
+            # ax.plot(BI_data.real, -BI_data.imag ,marker='.',ms=15,color='grey', alpha=0.5,label='predictive EIS')
+            # ax.plot(Zreal,-Zimag,'--',marker='o',c='b',alpha=0.9,ms=8,label = 'ground truth EIS')
+            ax.plot(BI_data.real, -BI_data.imag, marker=".", ms=15, color="grey", alpha=0.5, label="predictions")
+            ax.plot(Zreal, -Zimag, "--", marker="o", c="b", alpha=0.9, ms=8, label="grount truth")
+            ax.set_xlabel("Real(impedance)")
+            ax.set_ylabel("Im(impedance)")
             ax.set_title("Posterior predictive checks")
             if save:
-                plt.savefig(f"Posterior prediction.png", dpi=300)
+                plt.savefig(f"Posterior predictions.png", dpi=300)
             plt.legend(loc="upper left", fontsize=18)
             plt.show()
 
@@ -2235,9 +2189,11 @@ def Bayesian_inference(
         r_hats = []
         for i in range(len(name_i)):
             r_hats.append(
-                summary(mcmc_i.get_samples(), prob=0.94, group_by_chain=False)[f"{name_i[i]}"][
-                    "r_hat"
-                ]
+                summary(
+                    mcmc_i.get_samples(),
+                    prob=0.94,
+                    group_by_chain=False
+                )[f"{name_i[i]}"]["r_hat"]
             )
         posterior_rhat = np.mean(r_hats)
         consistency.append(posterior_rhat)

--- a/autoeis/_funcs.py
+++ b/autoeis/_funcs.py
@@ -329,7 +329,8 @@ def pre_processing(
     axes[2].set_ylabel(r"$-Im(Z) / \Omega$")
     axes[2].set_xlabel("freq (Hz)")
     axes[2].set_title("Non-filtered")
-    plt.savefig(f"{folder_name}\\Non-filtered_Nyquist and Bode plots.png", dpi=300)
+    saveto = os.path.join(folder_name, "Non-filtered Nyquist and Bode plots.png")
+    fig.savefig(saveto, dpi=300)
     plt.show()
 
     # Filter 1 - High Frequency Region
@@ -445,7 +446,8 @@ def pre_processing(
     axes[2].set_ylabel(r"$-Im(Z) / \Omega$")
     axes[2].set_xlabel("freq (Hz)")
     axes[2].set_title("Bode plot - Imaginary Part")
-    plt.savefig(f"{folder_name}\\Filtered_Nyquist and Bode plots.png", dpi=300)
+    saveto = os.path.join(folder_name, "Filtered Nyquist and Bode plots.png")
+    fig.savefig(saveto, dpi=300)
     plt.show()
 
     if threshold != 0.06:
@@ -485,11 +487,11 @@ def save_processed_data(input_name: str, data: "pd.DataFrame") -> str:
         file_name = input_name.split(".xlsx")[0]
     elif input_name.endswith(".pkl"):
         file_name = input_name.split(".pkl")[0]
-    data.to_csv(
-        folder_name + "//" + folder_name + "_processed" + ".csv", header=None, index=False
-    )
 
-    data.to_csv("temp" + ".csv", header=None, index=False)
+    saveto = os.path.join(folder_name, f"{file_name}_processed.csv")
+    data.to_csv(saveto, header=None, index=False)
+    data.to_csv("temp.csv", header=None, index=False)
+
     return file_name + ".csv"
 
 
@@ -2176,7 +2178,7 @@ def Bayesian_inference(
         if plot:
             az.plot_pair(mcmc_i, var_names=name_i)
             if save:
-                plt.savefig(f"Pair relationship plot_{circuit_name_i}.png", dpi=300)
+                plt.savefig(f"Pair relationship plot ({circuit_name_i}).png", dpi=300)
             plt.show()
 
         #         estimate posterior distribution
@@ -2227,14 +2229,16 @@ def Bayesian_inference(
     df_dict = df.to_dict()
     os.chdir(current_path)
     if save:
-        with open(f"{folder_name}//results.pkl", "wb") as handle:
+        saveto = os.path.join(folder_name, "results.pkl")
+        with open(saveto, "wb") as handle:
             dill.dump(df_dict, handle)
 
-    #         with open(f'{data_path}_results.json','w') as file_obj:
-    #             json.dum`bp(df_dict,file_obj)
+        # with open(f'{data_path}_results.json','w') as file_obj:
+        #     json.dumbp(df_dict,file_obj)
     # load data:
     # with open('file.pkl', 'rb') as f:
     #     input_dict = dill.load(f)
+
     return df
 
 

--- a/autoeis/closet.py
+++ b/autoeis/closet.py
@@ -1,0 +1,62 @@
+def EIS_auto_script(
+    impedance: "np.ndarray",
+    freq: "np.ndarray",
+    data_path: str,
+    iter_number: int = 100,
+    plot_ECM: bool = False,
+) -> "pd.DataFrame":
+    """
+    The main function to automate the whole EIS analysis by ECMs + BI.
+
+    Parameters
+    ----------
+    impedance: np.ndarray
+        The impedance data
+    freq: np.ndarray
+        The frequencies of the impedance data
+    data_path: str
+        The data path of the impedance data
+    iter_number: int
+        The number of times the ECM generation is performed
+    plot_ECM: bool
+        Determine whether to plot ECM or not
+
+    Returns
+    -------
+    results: pd.DataFrame
+        Dataframe containing effective ECMs after filtering + BI results (12 columns)
+
+    """
+    # Set the plotting style
+    set_parameter()
+    ec, jl_df, jl_pd, jl_Base = import_julia()
+
+    # Preprocessing + store preprocessed data
+    print("---------------Data_preprocessing---------------")
+    data_processed, ohmic_resistance, RMSE = pre_processing(impedance, freq, 0.05, data_path)
+    path_data_preprocessed = save_processed_data(
+        input_name=data_path, data=data_processed
+    )
+
+    # ECM generation
+    print("---------------ECM generation in process---------------")
+    # Alternative method: direcly call julia script - this might be faster
+    run_julia = j.include("test_julia.jl")
+
+    # Load the results - 1.from the results file
+    path_results = "df_results.csv"
+    df_circuits = load_results(fname=path_results)
+
+    # Load the results
+    df_circuits = split_components(df_results)
+    df_circuits = capacitance_filter(df_circuits)
+    df_circuits = series_filter(df_circuits)
+    df_circuits = ohmic_resistance_filter(df_circuits, ohmic_resistance)
+    df_circuits = generate_mathematical_expression(df_circuits)
+    new_df = combine_expression(df_circuits)
+    new_df = calculate_length(new_df)
+    new_df = split_variables(new_df)
+    results = Bayesian_inference(
+        data=data_processed, data_path=data_path, df=new_df, ECM_figure=plot_ECM
+    )
+    return results


### PR DESCRIPTION
Closes #19.

Among a batch of necessary stylistic changes (mainly for consistency), this PR adds a logging mechanism to be used instead of explicit calls to `print`. Logging is much better than printing to console since the logs are organized in 4-5 classes (info, warning, error, debug, trace), and they can be turned on/off on demand depending on what we need, as opposed to `print` which pollutes the console with all sorts of information.