### PR TITLE
Add new parameter fitter

### DIFF
--- a/.github/workflows/conda.yml
+++ b/.github/workflows/conda.yml
@@ -4,10 +4,10 @@ on: pull_request
 
 jobs:
   test:
-    runs-on: macos-14
+    runs-on: ubuntu-latest
     defaults:
       run:
-        shell: sh -l {0}
+        shell: bash
 
     steps:
       - uses: actions/checkout@v4
@@ -15,7 +15,7 @@ jobs:
         uses: conda-incubator/setup-miniconda@v3
         with:
           python-version: '3.10'
-          installer-url: https://github.com/conda-forge/miniforge/releases/download/23.11.0-0/Mambaforge-23.11.0-0-MacOSX-arm64.sh
+          miniforge-version: latest
       - name: "Install AutoEIS"
         run: |
             python -m pip install --upgrade pip

--- a/.gitignore
+++ b/.gitignore
@@ -166,6 +166,7 @@ examples/**/*.png
 examples/**/*.csv
 examples/**/*.txt
 results/
+*.pkl
 
 # Local development
 benchmark_jaxfit.py

--- a/autoeis/core.py
+++ b/autoeis/core.py
@@ -501,6 +501,38 @@ def perform_bayesian_inference(
     seed: Union[int, jax.Array] = None,
     progress_bar: bool = True,
     refine_p0: bool = False,
+) -> list[tuple[Union[numpyro.infer.mcmc.MCMC, None], int]]:
+    """Performs Bayesian inference on the circuits based on impedance data.
+
+    Parameters
+    ----------
+    circuits : pd.DataFrame or list[str]
+        Dataframe containing circuits or list of circuit strings.
+    Z : np.ndarray[complex]
+        Complex impedance data.
+    freq: np.ndarray[float]
+        Frequency data.
+    p0 : Union[np.ndarray[float], dict[str, float]], optional
+        Initial guess for the circuit parameters (default is None).
+    num_warmup : int, optional
+        Number of warmup samples for the MCMC (default is 2500).
+    num_samples : int, optional
+        Number of samples for the MCMC (default is 1000).
+    num_chains : int, optional
+        Number of MCMC chains (default is 1).
+    seed : int, optional
+        Random seed for reproducibility (default is None).
+    progress_bar : bool, optional
+        If True, a progress bar will be displayed (default is True).
+    refine_p0 : bool, optional
+        If True, the initial guess for the circuit parameters will be refined
+        using the circuit fitter (default is False).
+
+    Returns
+    -------
+    list[tuple[numpyro.infer.mcmc.MCMC, int]]
+        List of MCMC objects and exit codes (0 if successful, -1 if failed).
+    """
     # Ensure inputs are lists
     if isinstance(circuits, str):
         circuits = [circuits]
@@ -595,6 +627,7 @@ def _perform_bayesian_inference(
         key = jax.random.PRNGKey(seed)
         key, subkey = jax.random.split(key)
 
+    # TODO: Remove this, circuit fitting must be done in the public API
     # Deal with initial values for the circuit parameters
     if p0 is None:
         p0 = utils.fit_circuit_parameters(circuit, freq, Z)

--- a/autoeis/core.py
+++ b/autoeis/core.py
@@ -25,6 +25,7 @@ import numpyro
 import pandas as pd
 import psutil
 from impedance.validation import linKK
+from jax import config
 from mpire import WorkerPool
 from numpyro.infer import MCMC, NUTS
 from scipy.optimize import curve_fit
@@ -34,6 +35,8 @@ import autoeis.visualization as viz
 from autoeis import io, julia_helpers, metrics, parser, utils
 from autoeis.models import circuit_regression, circuit_regression_wrapped  # noqa: F401
 
+# Enforce double precision, otherwise circuit fitter fails (who knows what else!)
+config.update("jax_enable_x64", True)
 # AutoEIS datasets are not small-enough that CPU is much faster than GPU
 numpyro.set_platform("cpu")
 

--- a/autoeis/models.py
+++ b/autoeis/models.py
@@ -27,11 +27,11 @@ def circuit_regression(
 ):
     """NumpyRo model for Bayesian inference of circuit component values."""
     # Sample each element of X separately
-    X = jnp.array([numpyro.sample(k, v) for k, v in priors.items()])
+    p = jnp.array([numpyro.sample(k, v) for k, v in priors.items()])
     # Predict Z using the model
     circuit_fn = utils.generate_circuit_fn(circuit)
     circuit_fn = jax.jit(circuit_fn)
-    Z_pred = circuit_fn(X, freq)
+    Z_pred = circuit_fn(freq, p)
     # Define observation model for real and imaginary parts of Z
     sigma_real = numpyro.sample("sigma_real", dist.Exponential(rate=1.0))
     numpyro.sample("obs_real", dist.Normal(Z_pred.real, sigma_real), obs=Z.real)
@@ -47,9 +47,9 @@ def circuit_regression_wrapped(
 ):
     """NumpyRo model for Bayesian inference of circuit component values."""
     # Sample each element of X separately
-    X = jnp.array([numpyro.sample(k, v) for k, v in priors.items()])
+    p = jnp.array([numpyro.sample(k, v) for k, v in priors.items()])
     # Predict Z using the model
-    Z_pred = circuit_fn(X, freq)
+    Z_pred = circuit_fn(freq, p)
     # Define observation model for real and imaginary parts of Z
     sigma_real = numpyro.sample("sigma_real", dist.Exponential(rate=1.0))
     numpyro.sample("obs_real", dist.Normal(Z_pred.real, sigma_real), obs=Z.real)

--- a/autoeis/utils.py
+++ b/autoeis/utils.py
@@ -60,6 +60,8 @@ def get_logger(name: str) -> logging.Logger:
     return logger
 
 
+log = get_logger(__name__)
+
 # <<< Logging utils
 
 
@@ -158,7 +160,7 @@ def timeout(seconds):
             try:
                 result = func(*args, **kwargs)
             except TimeoutException:
-                print("Didn't converge in time!")
+                log.warning(f"{func.__name__} didn't converge in time!")
                 result = None
             finally:
                 signal.alarm(0)
@@ -299,8 +301,7 @@ def fit_circuit_parameters(
             popt, pcov = curve_fit(obj_fn, freq, Zc, **kwargs)
         except RuntimeError:
             continue
-        print(popt)
-        err = np.mean((obj_fn(freq, *popt) - Zc)**2)
+        err = np.mean((obj_fn(freq, *popt) - Zc) ** 2)
         if err < err_min:
             err_min = err
             p0 = popt
@@ -315,7 +316,7 @@ def fit_circuit_parameters(
 
 # FIXME: Timeout logic doesn't work on Windows -> module 'signal' has no attribute 'SIGALRM'.
 if os.name != "nt":
-    fit_circuit_parameters = timeout(300)(fit_circuit_parameters)
+    fit_circuit_parameters = timeout(15)(fit_circuit_parameters)
 
 
 def eval_circuit(

--- a/autoeis/utils.py
+++ b/autoeis/utils.py
@@ -32,9 +32,11 @@ import numpy as np
 import numpyro.distributions as dist
 import pandas as pd
 from impedance.models.circuits import CustomCircuit
+from impedance.models.circuits.fitting import set_default_bounds
 from numpy import pi  # NOQA: F401
 from rich.logging import RichHandler
 from scipy import stats
+from scipy.optimize import curve_fit
 
 # from tensorflow_probability import distributions as tfdist  # NOQA: F401
 import __main__

--- a/autoeis/utils.py
+++ b/autoeis/utils.py
@@ -23,8 +23,8 @@ import signal
 import sys
 from collections.abc import Iterable
 from contextlib import contextmanager
-from functools import partial, wraps
-from typing import Callable, Union
+from functools import wraps
+from typing import Union
 
 import jax  # NOQA: F401
 import jax.numpy as jnp

--- a/autoeis/utils.py
+++ b/autoeis/utils.py
@@ -215,7 +215,7 @@ def parse_initial_guess(
         return np.random.rand(num_params)
     elif isinstance(p0, dict):
         return np.fromiter(p0.values(), dtype=float)
-    elif isinstance(p0, list):
+    elif isinstance(p0, (list, np.ndarray)):
         return np.array(p0)
     raise ValueError(f"Invalid initial guess: {p0}")
 

--- a/autoeis/utils.py
+++ b/autoeis/utils.py
@@ -279,10 +279,7 @@ def fit_circuit_parameters(
 
     # Sanitize initial guess
     num_params = parser.count_parameters(circuit)
-    if p0 is None:
-        p0 = np.random.rand(num_params)
-    elif isinstance(p0, dict):
-        p0 = np.fromiter(p0.values(), dtype=float)
+    p0 = parse_initial_guess(p0, circuit)
     assert len(p0) == num_params, "Wrong number of parameters in initial guess."
 
     # Assemble kwargs for curve_fit

--- a/autoeis/utils.py
+++ b/autoeis/utils.py
@@ -251,7 +251,9 @@ if os.name != "nt":
     fit_circuit_parameters = timeout(300)(fit_circuit_parameters)
 
 
-def eval_circuit(circuit: str, x: np.ndarray[float], f: np.ndarray[float]) -> np.ndarray:
+def eval_circuit(
+    circuit: str, p: np.ndarray, f: Union[np.ndarray, float]
+) -> np.ndarray[complex]:
     """Converts a circuit string to a function of (params, freq) and evaluates it."""
     Z_expr = parser.generate_mathematical_expr(circuit)
     return eval(Z_expr)

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -6,6 +6,17 @@ import pytest
 from autoeis import core, io, utils
 
 
+def test_bayesian_inference_batch():
+    Z, freq = io.load_test_dataset()
+    # Only test first three circuits to save time in CI
+    circuits = io.load_test_circuits(filtered=True).iloc[:3]
+    mcmc_results = core.perform_bayesian_inference(circuits, freq, Z, refine_p0=True)
+    assert len(mcmc_results) == len(circuits)
+    for mcmc, exist_code in mcmc_results:
+        assert exist_code in [-1, 0]
+        assert isinstance(mcmc, numpyro.infer.mcmc.MCMC)
+
+
 def test_compute_ohmic_resistance():
     circuit_string = "R1-[P2,P3-R4]"
     circuit_fn = utils.generate_circuit_fn_impedance_backend(circuit_string)
@@ -81,21 +92,10 @@ def test_bayesian_inference_single():
         "num_samples": 1000,
         "progress_bar": False,
     }
-    mcmc, exist_code = core._perform_bayesian_inference(
-        circuit, freq, Z, p0, **kwargs_mcmc
-    )
-    assert exist_code in [-1, 0]
+    mcmcs = core.perform_bayesian_inference(circuit, freq, Z, p0, **kwargs_mcmc)
+    mcmc, exit_code = mcmcs[0]
+    assert exit_code in [-1, 0]
     assert isinstance(mcmc, numpyro.infer.mcmc.MCMC)
-
-
-def test_bayesian_inference_batch():
-    Z, freq = io.load_test_dataset()
-    circuits = io.load_test_circuits(filtered=True)
-    mcmc_results = core.perform_bayesian_inference(circuits, freq, Z)
-    assert len(mcmc_results) == len(circuits)
-    for mcmc, exist_code in mcmc_results:
-        assert exist_code in [-1, 0]
-        assert isinstance(mcmc, numpyro.infer.mcmc.MCMC)
 
 
 @pytest.mark.skip(reason="This test is too slow!")

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -11,7 +11,7 @@ y2 = x2 + np.zeros(10) * 1j
 
 # Simulated EIS data
 circuit_string = "R1-[P2,R3]"
-p0_dict = {"R1": 250, "P2w": 1e-3, "P2n": 0.5, "R3": 10}
+p0_dict = {"R1": 250, "P2w": 1e-3, "P2n": 0.5, "R3": 10.0}
 p0_vals = list(p0_dict.values())
 circuit_fn_gt = utils.generate_circuit_fn_impedance_backend(circuit_string)
 freq = np.logspace(-3, 3, 1000)

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -15,11 +15,11 @@ p0_dict = {"R1": 250, "P2w": 1e-3, "P2n": 0.5, "R3": 10}
 p0_vals = list(p0_dict.values())
 circuit_fn_gt = utils.generate_circuit_fn_impedance_backend(circuit_string)
 freq = np.logspace(-3, 3, 1000)
-Z = circuit_fn_gt(p0_vals, freq)
+Z = circuit_fn_gt(freq, p0_vals)
 
 
 def test_fit_circuit_parameters_without_x0():
-    p_dict = utils.fit_circuit_parameters(circuit_string, Z, freq, iters=5)
+    p_dict = utils.fit_circuit_parameters(circuit_string, freq, Z, iters=10)
     p_fit = list(p_dict.values())
     assert np.allclose(p_fit, p0_vals, rtol=0.01)
 
@@ -27,7 +27,7 @@ def test_fit_circuit_parameters_without_x0():
 def test_fit_circuit_parameters_with_x0():
     # Add some noise to the initial guess to test robustness
     p0 = p0_vals + np.random.rand(len(p0_vals)) * p0_vals * 0.5
-    p_dict = utils.fit_circuit_parameters(circuit_string, Z, freq, p0)
+    p_dict = utils.fit_circuit_parameters(circuit_string, freq, Z, p0)
     p_fit = list(p_dict.values())
     assert np.allclose(p_fit, p0_vals, rtol=0.01)
 
@@ -38,7 +38,7 @@ def test_generate_circuit_fn():
     freq = np.array([1, 10, 100])
     p = np.random.rand(num_params)
     circuit_fn = utils.generate_circuit_fn(circuit)
-    Z_py = circuit_fn(p, freq)
+    Z_py = circuit_fn(freq, p)
     Main = julia_helpers.init_julia()
     ec = julia_helpers.import_backend(Main)
     Z_jl = np.array([ec.get_target_impedance(circuit, p, f) for f in freq])


### PR DESCRIPTION
This PR adds a new parameter fitter. It still uses the same method as `impedance.py`, but is ~20x~ ~10x faster, so we can afford to brute-force our way into a pottentially good fit.

It also standardizes the circuit function signature: Used to be `fn(p, freq)`, now is `fn(freq, p)` to be intuitive. Also all functions that accept `Z` and `freq`, now accept it in the following order: `freq`, `Z`, again to be intuitive.