### PR TITLE
Fix ECM fitter not updating `p0` on next iterations

### DIFF
--- a/src/autoeis/utils.py
+++ b/src/autoeis/utils.py
@@ -65,6 +65,10 @@ log = logging.getLogger(__name__)
 # >>> General utils
 
 
+class DivergenceError(Exception):
+    pass
+
+
 def flush_streams():
     """Flushes the standard output and error streams."""
     sys.stdout.flush()
@@ -434,7 +438,8 @@ def fit_circuit_parameters(
     freq: np.ndarray[float],
     Z: np.ndarray[complex],
     p0: Mapping[str, float] | Iterable[float] = None,
-    iters: int = 1,
+    max_iters: int = 1,
+    min_iters: int = None,
     bounds: Iterable[tuple] = None,
     maxfev: int = None,
     ftol: float = 1e-8,
@@ -453,8 +458,12 @@ def fit_circuit_parameters(
         Impedance data.
     p0 : Mapping[str, float] | Iterable[float], optional
         Initial guess for the circuit parameters. Default is None.
-    iters : int, optional
+    max_iters : int, optional
         Maximum number of iterations for the circuit fitter. Default is 1.
+    min_iters : int, optional
+        Minimum number of iterations for the circuit fitter. Default is None.
+        If ``min_iters`` is reached AND circuit fitter converges, the fitting
+        process stops.
     bounds : Iterable[tuple], optional
         List of two tuples, each containing the lower and upper bounds,
         respectively, for the circuit parameters. Default is None. The order
@@ -502,20 +511,29 @@ def fit_circuit_parameters(
     kwargs = {"p0": p0, "bounds": bounds, "maxfev": maxfev, "ftol": ftol, "xtol": xtol}
 
     # Fit circuit parameters by brute force
+    min_iters = max_iters if min_iters is None else min_iters
     err_min = np.inf
-    for _ in range(iters):
+
+    for i in range(max_iters):
         try:
             popt, pcov = curve_fit(obj_fn, freq, Zc, **kwargs)
-        except Exception as e:
-            continue
-        err = gmean(np.abs((obj_fn(freq, *popt) - Zc) ** 2))
-        if err < err_min:
-            err_min = err
-            p0 = popt
+            err = np.mean(np.abs((obj_fn(freq, *popt) - Zc) ** 2))
+            if err < err_min:
+                err_min = err
+                p0 = popt
+            if i + 1 >= min_iters:
+                break
+        except RuntimeError:
+            pass  # DON'T 'continue', but 'pass', otherwise p0 will not be updated!
+        except ValueError:
+            raise
         kwargs["p0"] = generate_initial_guess(circuit)
 
     if err_min == np.inf:
-        raise Exception("Failed to fit the circuit parameters. Try increasing 'iters'.")
+        raise DivergenceError(
+            "Failed to fit the circuit parameters. Try increasing 'iters' or "
+            "'maxfev', or narrow down the search by providing 'bounds'."
+        )
 
     variables = parser.get_parameter_labels(circuit)
     return dict(zip(variables, p0))

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -41,7 +41,7 @@ def test_preprocess_impedance_data_no_high_freq():
 
 
 def test_fit_circuit_parameters_without_x0():
-    p_dict = ae.utils.fit_circuit_parameters(circuit_string, freq, Z, iters=100)
+    p_dict = ae.utils.fit_circuit_parameters(circuit_string, freq, Z, max_iters=100)
     p_fit = list(p_dict.values())
     assert np.allclose(p_fit, p0_vals, rtol=0.01)
 
@@ -58,7 +58,7 @@ def test_fit_circuit_parameters_with_bounds():
     # Pass incorrect bounds to ensure bounds are being used (Exception should be raised)
     bounds = [(0, 0, 0, 0), (1e-6, 1e-6, 1e-6, 1e-6)]
     with pytest.raises(Exception):
-        ae.utils.fit_circuit_parameters(circuit_string, freq, Z, iters=25, bounds=bounds)
+        ae.utils.fit_circuit_parameters(circuit_string, freq, Z, max_iters=25, bounds=bounds)
 
 
 def test_generate_circuit_fn():


### PR DESCRIPTION
Fixes #130 