### PR TITLE
Refactor circuit generation with unified backend interface

### DIFF
--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -6,7 +6,7 @@ import pytest
 
 def test_compute_ohmic_resistance():
     circuit_string = "R1-[P2,P3-R4]"
-    circuit_fn = ae.utils.generate_circuit_fn_impedance_backend(circuit_string)
+    circuit_fn = ae.utils.generate_circuit_fn(circuit_string, backend="impedance")
     R1 = 250
     parameters = np.array([R1, 1e-3, 0.1, 5e-5, 0.8, 10])
     freq = np.logspace(-3, 3, 1000)
@@ -17,7 +17,7 @@ def test_compute_ohmic_resistance():
 
 def test_compute_ohmic_resistance_missing_high_freq():
     circuit_string = "R1-[P2,P3-R4]"
-    circuit_fn = ae.utils.generate_circuit_fn_impedance_backend(circuit_string)
+    circuit_fn = ae.utils.generate_circuit_fn(circuit_string, backend="impedance")
     R1 = 250
     parameters = np.array([R1, 1e-3, 0.1, 5e-5, 0.8, 10])
     freq = np.logspace(-3, 0, 1000)


### PR DESCRIPTION
## Summary
• Unify circuit generation functions into single `generate_circuit_fn` interface with backend parameter
• Add support for numpy (default), jax, numexpr, and impedance backends
• Enable batch evaluation for multiple parameter sets across numpy/jax/numexpr backends
• Maintain backward compatibility with existing `jit=True` parameter

## Changes
- **Backend Support**: Unified interface with 4 computational backends
- **Batch Processing**: Efficient vectorized evaluation for multiple parameter sets
- **Testing**: Comprehensive parametrized test coverage across all backends
- **API Simplification**: Single function replaces multiple specialized functions

## Test Coverage
All backends tested for:
- Basic functionality with complex and concatenated output modes
- Consistency across different backends
- Batch evaluation capabilities (where supported)
- Edge cases and error handling

🤖 Generated with [Claude Code](https://claude.ai/code)